### PR TITLE
chore(demo): add shm_kv doc and test config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ This will produce a .wasm file in `target/wasm32-wasi/release/`.
 Once you have a Wasm-enabled Kong container with a recent ngx_wasm_module
 integrated (the container from the Summit 2022 Tech Preview is too old),
 you can run the script in `test/demo.sh` to give the filter a spin.
+
+You also need the `kong_wasm_rate_limiting_counters` shared memory
+key-value store enabled in your Kong configuration. One way to
+achieve this is via the following environment variable:
+
+```sh
+export KONG_NGINX_WASM_SHM_KONG_WASM_RATE_LIMITING_COUNTERS=12m
+```

--- a/test/demo.sh
+++ b/test/demo.sh
@@ -56,6 +56,7 @@ docker run -d --name "$DEMO_KONG_CONTAINER" \
     -e "KONG_DATABASE=off" \
     -e "KONG_NGINX_WORKER_PROCESSES=1" \
     -e "KONG_DECLARATIVE_CONFIG=/kong/config/demo.yml" \
+    -e "KONG_NGINX_WASM_SHM_KONG_WASM_RATE_LIMITING_COUNTERS=12m" \
     -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
     -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
     -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \


### PR DESCRIPTION
I've essentially just applied these 2 recent commits from the golang repo:

* https://github.com/Kong/proxy-wasm-go-rate-limiting/commit/6a477ee701e4f27c6f948619c4169c248c45a6df
* https://github.com/Kong/proxy-wasm-go-rate-limiting/commit/edb8b2c4b523a3b99f073644448d5c05d4b2310a


There are some cobwebs in here yet (I am seeing that the demo yaml still references the `proxy-wasm` plugin), but this makes things at least a bit more consistent with the golang repo.

KAG-2080